### PR TITLE
Add an explicitly defined opengl dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('imgui-sfml', 'cpp',
 
 imgui_dep = dependency('imgui')
 sfml_dep = dependency('sfml')
+gl_dep = dependency('gl')
 
 # We do not look up sfml here because there are many different
 # names for the .pc files and others and it is unclear which
@@ -15,7 +16,7 @@ sfml_dep = dependency('sfml')
 # more usage experience.
 
 is_lib = library('imgui-sfml', 'imgui-SFML.cpp',
-    dependencies: [sfml_dep, imgui_dep])
+    dependencies: [sfml_dep, imgui_dep, gl_dep])
 
 imgui_sfml_dep = declare_dependency(include_directories: '.',
                                     dependencies: imgui_dep,


### PR DESCRIPTION
Using the build definition in the repository produces a link error due to missing gl symbols. Adding opengl as an explicit dependency seems to fix this.